### PR TITLE
Add support for "RewriteToPath" attribute

### DIFF
--- a/pyro/Constants.py
+++ b/pyro/Constants.py
@@ -35,6 +35,7 @@ class XmlAttributeName(Constant):
     PACKAGE: str = 'Package'
     PATH: str = 'Path'
     RELEASE: str = 'Release'
+    REWRITE_TO_PATH: str = 'RewriteToPath'
     ROOT_DIR: str = 'RootDir'
     USE_IN_BUILD: str = 'UseInBuild'
     VALUE: str = 'Value'

--- a/pyro/PapyrusProject.py
+++ b/pyro/PapyrusProject.py
@@ -300,6 +300,7 @@ class PapyrusProject(ProjectBase):
 
         other_bool_keys = [
             XmlAttributeName.NO_RECURSE,
+            XmlAttributeName.REWRITE_TO_PATH,
             XmlAttributeName.USE_IN_BUILD
         ]
 
@@ -336,6 +337,9 @@ class PapyrusProject(ProjectBase):
                 if tag in (XmlTagName.INCLUDE, XmlTagName.MATCH):
                     if XmlAttributeName.PATH not in node.attrib:
                         node.set(XmlAttributeName.PATH, '')
+                if tag == XmlTagName.INCLUDE:
+                    if XmlAttributeName.REWRITE_TO_PATH not in node.attrib:
+                        node.set(XmlAttributeName.REWRITE_TO_PATH, 'False')
                 if tag == XmlTagName.MATCH:
                     if XmlAttributeName.IN not in node.attrib:
                         node.set(XmlAttributeName.IN, os.curdir)

--- a/pyro/PapyrusProject.xsd
+++ b/pyro/PapyrusProject.xsd
@@ -6,7 +6,7 @@
     xmlns="PapyrusProject.xsd"
     xmlns:pyro="PapyrusProject.xsd"
     xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    
+
     <!-- Elements -->
     <xs:element name="PapyrusProject">
         <xs:complexType>
@@ -47,7 +47,7 @@
         <xs:sequence>
             <xs:element maxOccurs="unbounded" name="Variable" type="pyro:nameValuePair"/>
         </xs:sequence>
-    </xs:complexType>    
+    </xs:complexType>
     <xs:complexType name="importList">
         <xs:sequence>
             <xs:element maxOccurs="unbounded" name="Import" type="xs:string"/>
@@ -82,7 +82,7 @@
         <xs:attribute name="Description" type="xs:string"/>
         <xs:attribute name="UseInBuild" type="pyro:bool"/>
     </xs:complexType>
-    
+
     <!-- Reusable Complex Types -->
     <xs:complexType name="nameValuePair">
         <xs:attribute name="Name" type="xs:string" use="required"/>
@@ -95,6 +95,7 @@
         <xs:complexContent>
             <xs:extension base="recursablePath">
                 <xs:attribute name="Path" type="xs:string" default=""/>
+                <xs:attribute name="RewriteToPath" type="pyro:bool" default="false"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -124,7 +125,7 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-    
+
     <!-- Simple Types -->
     <xs:simpleType name="asmType">
         <xs:restriction base="xs:string">


### PR DESCRIPTION
This change adds support for the "RewriteToPath" attribute on
Packages.Package.Include elements. The RewriteToPath attribute tells
pyro to strip off the path information for any files found in the
particular Include element, and directly append the resulting base
filename to the (non-empty) Path attribute of the same Include element.